### PR TITLE
fix issue that can't popover twice with the same popover instance.

### DIFF
--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -239,6 +239,7 @@ open class Popover: UIView {
           self.contentView.removeFromSuperview()
           self.blackOverlay.removeFromSuperview()
           self.removeFromSuperview()
+          self.transform = CGAffineTransform.identity
           self.didDismissHandler?()
       }
     }


### PR DESCRIPTION
I have met the issue #25. And found that it didn't reset the transform of Popover view when call dismiss.

It will cause Popover view can't be shown second time. Because the frame of Popover view is calculated wrong.

I use Xcode is 8.0 (8A218a) with Cocoapods 1.1.0 under swift 2.3

But I think the framework should support show popover again from the same instance. 