### PR TITLE
Hide overlay option

### DIFF
--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -20,6 +20,7 @@ public enum PopoverOption {
   case type(PopoverType)
   case color(UIColor)
   case dismissOnBlackOverlayTap(Bool)
+  case showBlackOverlay(Bool)
 }
 
 @objc public enum PopoverType: Int {
@@ -40,6 +41,7 @@ open class Popover: UIView {
   open var overlayBlur: UIBlurEffect?
   open var popoverColor: UIColor = UIColor.white
   open var dismissOnBlackOverlayTap: Bool = true
+  open var showBlackOverlay: Bool = true
 
   // custom closure
   open var willShowHandler: (() -> ())?
@@ -100,6 +102,8 @@ open class Popover: UIView {
           self.popoverColor = value
         case let .dismissOnBlackOverlayTap(value):
           self.dismissOnBlackOverlayTap = value
+        case let .showBlackOverlay(value):
+            self.showBlackOverlay = value
         }
       }
     }
@@ -184,23 +188,25 @@ open class Popover: UIView {
   }
 
   open func show(_ contentView: UIView, point: CGPoint, inView: UIView) {
-    self.blackOverlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    self.blackOverlay.frame = inView.bounds
+    if showBlackOverlay {
+        self.blackOverlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.blackOverlay.frame = inView.bounds
 
-    if let overlayBlur = self.overlayBlur {
-      let effectView = UIVisualEffectView(effect: overlayBlur)
-      effectView.frame = self.blackOverlay.bounds
-      effectView.isUserInteractionEnabled = false
-      self.blackOverlay.addSubview(effectView)
-    } else {
-      self.blackOverlay.backgroundColor = self.blackOverlayColor
-      self.blackOverlay.alpha = 0
-    }
+        if let overlayBlur = self.overlayBlur {
+          let effectView = UIVisualEffectView(effect: overlayBlur)
+          effectView.frame = self.blackOverlay.bounds
+          effectView.isUserInteractionEnabled = false
+          self.blackOverlay.addSubview(effectView)
+        } else {
+          self.blackOverlay.backgroundColor = self.blackOverlayColor
+          self.blackOverlay.alpha = 0
+        }
 
-    inView.addSubview(self.blackOverlay)
-    
-    if self.dismissOnBlackOverlayTap {
-        self.blackOverlay.addTarget(self, action: #selector(Popover.dismiss), for: .touchUpInside)
+        inView.addSubview(self.blackOverlay)
+        
+        if self.dismissOnBlackOverlayTap {
+            self.blackOverlay.addTarget(self, action: #selector(Popover.dismiss), for: .touchUpInside)
+        }
     }
 
     self.containerView = inView


### PR DESCRIPTION
Allows user to hide overlay, which allows taps on the UI to be processed normally. Useful for apps that want to hide/show popovers based on user actions.