### PR TITLE
Fix crash in default show() methods

### DIFF
--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -174,7 +174,7 @@ open class Popover: UIView {
   }
 
   open func showAsDialog(_ contentView: UIView) {
-    self.showAsDialog(contentView, inView: UIApplication.shared.keyWindow!)
+    self.showAsDialog(contentView, inView: UIApplication.shared.windows.first!)
   }
 
   open func showAsDialog(_ contentView: UIView, inView: UIView) {
@@ -185,7 +185,7 @@ open class Popover: UIView {
   }
 
   open func show(_ contentView: UIView, fromView: UIView) {
-    self.show(contentView, fromView: fromView, inView: UIApplication.shared.keyWindow!)
+    self.show(contentView, fromView: fromView, inView: UIApplication.shared.windows.first!)
   }
 
   open func show(_ contentView: UIView, fromView: UIView, inView: UIView) {
@@ -205,7 +205,7 @@ open class Popover: UIView {
   }
 
   open func show(_ contentView: UIView, point: CGPoint) {
-    self.show(contentView, point: point, inView: UIApplication.shared.keyWindow!)
+    self.show(contentView, point: point, inView: UIApplication.shared.windows.first!)
   }
 
   open func show(_ contentView: UIView, point: CGPoint, inView: UIView) {


### PR DESCRIPTION
This is a quick workaround but in the future it should be coded in a safer way.