### PR TITLE
Bugfix for PR #63

### DIFF
--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -174,7 +174,10 @@ open class Popover: UIView {
   }
 
   open func showAsDialog(_ contentView: UIView) {
-    self.showAsDialog(contentView, inView: UIApplication.shared.windows.first!)
+    guard let rootView = UIApplication.shared.windows.last ?? UIApplication.shared.keyWindow else {
+        return
+    }
+    self.showAsDialog(contentView, inView: rootView)
   }
 
   open func showAsDialog(_ contentView: UIView, inView: UIView) {
@@ -185,7 +188,10 @@ open class Popover: UIView {
   }
 
   open func show(_ contentView: UIView, fromView: UIView) {
-    self.show(contentView, fromView: fromView, inView: UIApplication.shared.windows.first!)
+    guard let rootView = UIApplication.shared.windows.last ?? UIApplication.shared.keyWindow else {
+        return
+    }
+    self.show(contentView, fromView: fromView, inView: rootView)
   }
 
   open func show(_ contentView: UIView, fromView: UIView, inView: UIView) {
@@ -205,7 +211,10 @@ open class Popover: UIView {
   }
 
   open func show(_ contentView: UIView, point: CGPoint) {
-    self.show(contentView, point: point, inView: UIApplication.shared.windows.first!)
+    guard let rootView = UIApplication.shared.windows.last ?? UIApplication.shared.keyWindow else {
+        return
+    }
+    self.show(contentView, point: point, inView: rootView)
   }
 
   open func show(_ contentView: UIView, point: CGPoint, inView: UIView) {


### PR DESCRIPTION
Will use .last instead of .first on current windows view controllers, fallback to keyWindow + gracefully try to unwrap instead of forcing it, which could result in a crash.

Thank you for making this lib, I hope you can use the PR.