### PR TITLE
New option: .dismissOnPopover

### DIFF
--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -21,6 +21,7 @@ public enum PopoverOption {
   case color(UIColor)
   case dismissOnBlackOverlayTap(Bool)
   case showBlackOverlay(Bool)
+  case dismissOnPopover
 }
 
 @objc public enum PopoverType: Int {
@@ -42,6 +43,7 @@ open class Popover: UIView {
   open var popoverColor: UIColor = UIColor.white
   open var dismissOnBlackOverlayTap: Bool = true
   open var showBlackOverlay: Bool = true
+  open var dismissOnPopover: Bool = false
   open var highlightFromView: Bool = false
   open var highlightCornerRadius: CGFloat = 0
 
@@ -106,6 +108,8 @@ open class Popover: UIView {
           self.dismissOnBlackOverlayTap = value
         case let .showBlackOverlay(value):
             self.showBlackOverlay = value
+        case .dismissOnPopover:
+            self.dismissOnPopover = true
         }
       }
     }
@@ -239,6 +243,10 @@ open class Popover: UIView {
         if self.dismissOnBlackOverlayTap {
             self.blackOverlay.addTarget(self, action: #selector(Popover.dismiss), for: .touchUpInside)
         }
+    }
+    
+    if self.dismissOnPopover {
+        inView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(Popover.dismiss)))
     }
 
     self.containerView = inView

--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -58,6 +58,7 @@ open class Popover: UIView {
   fileprivate var contentView: UIView!
   fileprivate var contentViewFrame: CGRect!
   fileprivate var arrowShowPoint: CGPoint!
+  fileprivate var tapGestureRecognizer: UITapGestureRecognizer?
 
   public init() {
     super.init(frame: CGRect.zero)
@@ -246,7 +247,9 @@ open class Popover: UIView {
     }
     
     if self.dismissOnPopover {
-        inView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(Popover.dismiss)))
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(Popover.dismiss))
+        inView.addGestureRecognizer(tapGestureRecognizer)
+        self.tapGestureRecognizer = tapGestureRecognizer
     }
 
     self.containerView = inView
@@ -310,6 +313,9 @@ open class Popover: UIView {
           self.transform = CGAffineTransform.identity
           self.didDismissHandler?()
       }
+    }
+    if let tapGestureRecognizer = tapGestureRecognizer {
+        containerView.removeGestureRecognizer(tapGestureRecognizer)
     }
   }
 

--- a/Example/Popover/ViewController.swift
+++ b/Example/Popover/ViewController.swift
@@ -47,10 +47,9 @@ class ViewController: UIViewController {
 
   @IBAction func tappedRightButtomButton(_ sender: UIButton) {
     let tableView = UITableView(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: 135))
-    tableView.delegate = self
     tableView.dataSource = self
     tableView.isScrollEnabled = false
-    self.popover = Popover(options: self.popoverOptions)
+    self.popover = Popover(options: self.popoverOptions + [.dismissOnPopover])
     self.popover.willShowHandler = {
       print("willShowHandler")
     }
@@ -64,13 +63,6 @@ class ViewController: UIViewController {
       print("didDismissHandler")
     }
     self.popover.show(tableView, fromView: self.rightButtomButton)
-  }
-}
-
-extension ViewController: UITableViewDelegate {
-
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    self.popover.dismiss()
   }
 }
 


### PR DESCRIPTION
Hey @corin8823 ! Love the simplicity of the popover, and I'd like to use it in my app! 🐻 I was missing one option: to dismiss on popover tap, so I added it!

Also, I spotted one bug. When you define a method in example project, like this:
```
  @IBAction func tappedLeftBottomButton(_ sender: UIButton) {
    let width = self.view.frame.width / 4
    let aView = UIView(frame: CGRect(x: 0, y: 0, width: width, height: width))
    let options = [
      .type(.up),
      .showBlackOverlay(false)
      ] as [PopoverOption]
    let popover = Popover(options: options, showHandler: nil, dismissHandler: nil)
    popover.show(aView, fromView: self.leftBottomButton)
  }
```
Then you can't dismiss this popup by tapping on button. The solution is:
```
  open func show(_ contentView: UIView, point: CGPoint, inView: UIView) {
    if let visiblePopover = inView.subviews.flatMap({ $0 as? Popover }).first, showBlackOverlay == false {
        visiblePopover.dismiss()
        return
    }
```
But I didn't add it, because it would dismiss other opened popover. But if you have only on popover on-screen then this would do the trick.

Cheers!