### PR TITLE
Avoid blackOverlay view to trap user interactions if not needed

### DIFF
--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -218,30 +218,30 @@ open class Popover: UIView {
   }
 
   open func show(_ contentView: UIView, point: CGPoint, inView: UIView) {
-    self.blackOverlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    self.blackOverlay.frame = inView.bounds
-    inView.addSubview(self.blackOverlay)
-
-    if showBlackOverlay {
-        if let overlayBlur = self.overlayBlur {
-          let effectView = UIVisualEffectView(effect: overlayBlur)
-          effectView.frame = self.blackOverlay.bounds
-          effectView.isUserInteractionEnabled = false
-          self.blackOverlay.addSubview(effectView)
-        } else {
-          if !self.highlightFromView {
-            self.blackOverlay.backgroundColor = self.blackOverlayColor
-          }
-          self.blackOverlay.alpha = 0
+    if self.dismissOnBlackOverlayTap || self.showBlackOverlay {
+        self.blackOverlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.blackOverlay.frame = inView.bounds
+        inView.addSubview(self.blackOverlay)
+        
+        if showBlackOverlay {
+            if let overlayBlur = self.overlayBlur {
+                let effectView = UIVisualEffectView(effect: overlayBlur)
+                effectView.frame = self.blackOverlay.bounds
+                effectView.isUserInteractionEnabled = false
+                self.blackOverlay.addSubview(effectView)
+            } else {
+                if !self.highlightFromView {
+                    self.blackOverlay.backgroundColor = self.blackOverlayColor
+                }
+                self.blackOverlay.alpha = 0
+            }
+        }
+        
+        if self.dismissOnBlackOverlayTap {
+            self.blackOverlay.addTarget(self, action: #selector(Popover.dismiss), for: .touchUpInside)
         }
     }
-
-    if self.dismissOnBlackOverlayTap {
-        self.blackOverlay.addTarget(self, action: #selector(Popover.dismiss), for: .touchUpInside)
-    } else {
-        self.blackOverlay.isUserInteractionEnabled = false
-    }
-
+    
     self.containerView = inView
     self.contentView = contentView
     self.contentView.backgroundColor = UIColor.clear

--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -238,6 +238,8 @@ open class Popover: UIView {
 
     if self.dismissOnBlackOverlayTap {
         self.blackOverlay.addTarget(self, action: #selector(Popover.dismiss), for: .touchUpInside)
+    } else {
+        self.blackOverlay.isUserInteractionEnabled = false
     }
 
     self.containerView = inView


### PR DESCRIPTION
When showBlackOverlay and dismissOnBlackOverlayTap are false, we not want blackOverlay to be added to view hierarchy to avoid it to trap user interaction.

For instance, if a popover is use to explain a button, we want the user to be able to tap it. Since 1.0.6 it was no more possible.