### PR TITLE
Additional setting, that enables the popover to automatically avoid bottom screen edge

### DIFF
--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -120,7 +120,8 @@ open class Popover: UIView {
     let point: CGPoint
     
     if self.popoverType == .auto {
-        if let point = fromView.superview?.convert(fromView.frame.origin, to: nil), point.y + contentView.frame.height + 75 > inView.frame.height {
+        if let point = fromView.superview?.convert(fromView.frame.origin, to: nil),
+            point.y + fromView.frame.height + self.arrowSize.height + contentView.frame.height > inView.frame.height {
             self.popoverType = .up
         } else {
             self.popoverType = .down

--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -28,6 +28,7 @@ public enum PopoverOption {
 @objc public enum PopoverType: Int {
   case up
   case down
+  case auto
 }
 
 open class Popover: UIView {
@@ -117,6 +118,15 @@ open class Popover: UIView {
 
   open func show(_ contentView: UIView, fromView: UIView, inView: UIView) {
     let point: CGPoint
+    
+    if self.popoverType == .auto {
+        if let point = fromView.superview?.convert(fromView.frame.origin, to: nil), point.y + contentView.frame.height + 75 > inView.frame.height {
+            self.popoverType = .up
+        } else {
+            self.popoverType = .down
+        }
+    }
+    
     switch self.popoverType {
     case .up:
       point = inView.convert(
@@ -124,7 +134,7 @@ open class Popover: UIView {
           x: fromView.frame.origin.x + (fromView.frame.size.width / 2),
           y: fromView.frame.origin.y
       ), from: fromView.superview)
-    case .down:
+    case .down, .auto:
       point = inView.convert(
         CGPoint(
           x: fromView.frame.origin.x + (fromView.frame.size.width / 2),
@@ -269,7 +279,7 @@ open class Popover: UIView {
         )
       )
 
-    case .down:
+    case .down, .auto:
       arrow.move(to: CGPoint(x: arrowPoint.x, y: 0))
       arrow.addLine(
         to: CGPoint(
@@ -394,7 +404,7 @@ private extension Popover {
     case .up:
       frame.origin.y = self.arrowShowPoint.y - frame.height - self.arrowSize.height
       anchorPoint = CGPoint(x: arrowPoint.x / frame.size.width, y: 1)
-    case .down:
+    case .down, .auto:
       frame.origin.y = self.arrowShowPoint.y
       anchorPoint = CGPoint(x: arrowPoint.x / frame.size.width, y: 0)
     }
@@ -432,7 +442,7 @@ private extension Popover {
     switch self.popoverType {
     case .up:
       self.contentView.frame.origin.y = 0.0
-    case .down:
+    case .down, .auto:
       self.contentView.frame.origin.y = self.arrowSize.height
     }
     self.addSubview(self.contentView)

--- a/Example/Popover/ViewController.swift
+++ b/Example/Popover/ViewController.swift
@@ -19,7 +19,7 @@ class ViewController: UIViewController {
 
   fileprivate var popover: Popover!
   fileprivate var popoverOptions: [PopoverOption] = [
-    .type(.up),
+    .type(.auto),
     .blackOverlayColor(UIColor(white: 0.0, alpha: 0.6))
   ]
 


### PR DESCRIPTION
There is a 3rd setting for popoverType now. Choosing it will make popover attempt to select proper type, `.up` or `.down`, depending on how much room there is left to the bottom screen edge. Defaults to `.down` if anything goes wrong.

Usage:
`popover.popoverType = .auto`

The default type (which is `.down` at the moment) was not changed, because this new `.auto` option might probably need better testing on different orientations.