### PR TITLE
Add support for Objective-C

### DIFF
--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -31,6 +31,7 @@ public enum PopoverOption {
   case auto
 }
 
+@objcMembers
 open class Popover: UIView {
 
   // custom property


### PR DESCRIPTION
This fix allows PopoverExampleObjc to be built with Xcode 10.2

Because of swift4 behavior we have to add `@objc` to each classes and methods to use swift classes in Objective-C. We can use `@objcMembers` instead of adding `@objc` to all each methods.
