### PR TITLE
build: fix the compilation error with xcode 16

### DIFF
--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -614,8 +614,10 @@ private extension Popover {
 
     let fillLayer = CAShapeLayer()
     fillLayer.path = path.cgPath
-    fillLayer.fillRule = CAShapeLayerFillRule.evenOdd
     fillLayer.fillColor = self.blackOverlayColor.cgColor
+    if #available(iOS 12.0, *) {
+      fillLayer.fillRule = CAShapeLayerFillRule.evenOdd
+    }
     self.blackOverlay.layer.addSublayer(fillLayer)
   }
 

--- a/Popover.podspec
+++ b/Popover.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Popover"
-  s.version          = "1.3.0"
+  s.version          = "1.4.0"
   s.summary          = "Popover is a balloon library like facebook app. It is written in pure swift."
   s.homepage         = "https://github.com/corin8823"
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/Popover.xcodeproj/project.pbxproj
+++ b/Popover.xcodeproj/project.pbxproj
@@ -277,7 +277,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Supporting files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = dk.simonbs.Popover;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -298,7 +298,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Supporting files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = dk.simonbs.Popover;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
- Starting with iOS18, CAShapeLayerFillRule is marked as iOS12 only.

- Increase the iOS deployment target to iOS11 because libarclite is now obsolete